### PR TITLE
Don't hardcode a hostname for serving static files

### DIFF
--- a/botify_docs/settings/deploy_prod.py
+++ b/botify_docs/settings/deploy_prod.py
@@ -4,7 +4,7 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['testserver']
 
-STATIC_URL = 'https://developers.botify.com/staticfiles/'
+STATIC_URL = '/staticfiles/'
 
 MEDUSA_RENDERER_CLASS = "django_medusa.renderers.DiskStaticSiteRenderer"
 MEDUSA_DEPLOY_DIR = os.path.join(

--- a/botify_docs/settings/deploy_staging.py
+++ b/botify_docs/settings/deploy_staging.py
@@ -4,7 +4,7 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['testserver']
 
-STATIC_URL = 'http://com.botify.saas.staging.developer-docs.s3-website-eu-west-1.amazonaws.com/staticfiles/'
+STATIC_URL = '/staticfiles/'
 
 MEDUSA_RENDERER_CLASS = "django_medusa.renderers.DiskStaticSiteRenderer"
 MEDUSA_DEPLOY_DIR = os.path.join(


### PR DESCRIPTION
This will allow to test production deployment without Cloudfront on:
https://s3.amazonaws.com/com.botify.saas.production.developer-docs/index.html

I don't know if we can move STATIC_URL back to base.py => it may break some local.py settings... What do you think?

The change has been tested on staging succesfully: http://com.botify.saas.staging.developer-docs.s3-website-eu-west-1.amazonaws.com/

<!---
@huboard:{"custom_state":"archived"}
-->
