### PR TITLE
Update 'between' predicate note

### DIFF
--- a/api_docs/markdowns/api/bql/bql-filter.md
+++ b/api_docs/markdowns/api/bql/bql-filter.md
@@ -71,7 +71,7 @@ Can be applied to numerical fields, including `integer`, `long`, `float`, `doubl
   "value": [200, 300]
 }
 ```
-**Note**: Lower boundary is inclusive whereas **upper boundary is exclusive**. For instance the above example means `200 <= http_code < 300`.
+**Note**: Lower and upper boundaies are inclusive. For instance the above example means `200 <= http_code <= 300`.
 
 
 ### Categorical Predicates


### PR DESCRIPTION
The "between" in BQL means that both boundaries are taken into account (no matter the backend used: ES or BQ)

Example:
1. hits ElasticSearch and includes 3
```
curl --location --request POST 'https://api.botify.com/v1/analyses/the-globe-and-mail/the-globe-and-mail-2m-url-weekly-crawl-js/20200314/urls?area=current&page=1&size=50&previous_crawl=20200307' \
--header 'authority: api.botify.com' \
--header 'accept: application/json; version=1.0.0' \
--header 'authorization: Token XXX' \
--header 'x-botify-client: crawl-report' \
--header 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36' \
--header 'content-type: application/json; charset=UTF-8' \
--header 'origin: https://app.botify.com' \
--header 'sec-fetch-site: same-site' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-dest: empty' \
--header 'referer: https://app.botify.com/the-globe-and-mail/the-globe-and-mail-2m-url-weekly-crawl-js/crawl/explorer?analysisSlug=20200314&explorerFilter=%7B%22filters%22%3A%7B%22and%22%3A%5B%7B%22and%22%3A%5B%7B%22not%22%3A%7B%22predicate%22%3A%22in_the_last%22%2C%22value%22%3A%7B%22count%22%3A30%2C%22unit%22%3A%22day%22%7D%2C%22field%22%3A%22metadata.structured.dates.date_published%22%7D%7D%5D%7D%5D%7D%2C%22sort%22%3A%5B%7B%22metadata.structured.dates.date_published%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22columns%22%3A%5B%22url_card%22%2C%22metadata.structured.dates.date_published%22%5D%7D&comparisonAnalysisSlug=20200307' \
--header 'accept-language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7,nb;q=0.6' \
--header 'Cookie: csrftoken=Ltfeip3E2qFKFa6m7flCQmIYqcaKpUa3' \
--data-raw '{
    "filters": {
            "predicate": "between",
            "value": [
                1,
                3
            ],
            "field": "depth"
        
    },
    "fields": [
        "url",
        "depth"
    ],
    "sort": [
        {
            "depth": {
                "order": "desc"
            }
        }
    ]
}'
```

On BQ:
```
curl --location --request POST 'https://api.botify.com/v1/analyses/the-globe-and-mail/the-globe-and-mail-2m-url-weekly-crawl-js/20200314/urls?area=current&page=1&size=50&previous_crawl=20200307' \
--header 'authority: api.botify.com' \
--header 'accept: application/json; version=1.0.0' \
--header 'authorization: Token XXX' \
--header 'x-botify-client: crawl-report' \
--header 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36' \
--header 'content-type: application/json; charset=UTF-8' \
--header 'origin: https://app.botify.com' \
--header 'sec-fetch-site: same-site' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-dest: empty' \
--header 'referer: https://app.botify.com/the-globe-and-mail/the-globe-and-mail-2m-url-weekly-crawl-js/crawl/explorer?analysisSlug=20200314&explorerFilter=%7B%22filters%22%3A%7B%22and%22%3A%5B%7B%22and%22%3A%5B%7B%22not%22%3A%7B%22predicate%22%3A%22in_the_last%22%2C%22value%22%3A%7B%22count%22%3A30%2C%22unit%22%3A%22day%22%7D%2C%22field%22%3A%22metadata.structured.dates.date_published%22%7D%7D%5D%7D%5D%7D%2C%22sort%22%3A%5B%7B%22metadata.structured.dates.date_published%22%3A%7B%22order%22%3A%22desc%22%7D%7D%5D%2C%22columns%22%3A%5B%22url_card%22%2C%22metadata.structured.dates.date_published%22%5D%7D&comparisonAnalysisSlug=20200307' \
--header 'accept-language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7,nb;q=0.6' \
--header 'Cookie: csrftoken=Ltfeip3E2qFKFa6m7flCQmIYqcaKpUa3' \
--data-raw '{
    "filters": {
        "not": {
            "predicate": "between",
            "value": [
                "2020-02-14",
                "2020-03-14"
            ],
            "field": "metadata.structured.dates.date_published"
        }
    },
    "fields": [
        "url",
        "metadata.title.contents",
        "main_image",
        "metadata.structured.dates.date_published"
    ],
    "sort": [
        {
            "metadata.structured.dates.date_published": {
                "order": "desc"
            }
        }
    ]
}'
```

does a SQL query:
```
SELECT a.url url, a.metadata__title__contents metadata__title__contents, a.main_image main_image, a.metadata__structured__dates__date_published metadata__structured__dates__date_published FROM (SELECT url, metadata__title__contents, main_image, metadata__structured__dates__date_published FROM `botify-production-10.production_47049.crawl_435244_463229` WHERE http_code <> 0 AND NOT(metadata__structured__dates__date_published BETWEEN '2020-02-14' AND '2020-03-14')) a ORDER BY 4 desc LIMIT 50000
```
As one can see:
`metadata__structured__dates__date_published BETWEEN '2020-02-14' AND '2020-03-14'`
and from the doc: https://cloud.google.com/bigquery/docs/reference/standard-sql/operators#comparison_operators
> The result of "X BETWEEN Y AND Z" is equivalent to "Y <= X AND X <= Z" [...]