### PR TITLE
bug/DATA-11159/remove-tracking-from-developers-site

### DIFF
--- a/api_docs/templates/base/common_page.html
+++ b/api_docs/templates/base/common_page.html
@@ -67,12 +67,5 @@
     {% block extra_script %}
     {% endblock %}
   {% endif %}
-
-  <script type="text/javascript">
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
-      analytics.load('5ivE9AeJNB6kq17VSycO582DfUt7F2zw');
-      analytics.page();
-    }}();
-  </script>
 </body>
 </html>

--- a/botify_docs/templates/homepage.html
+++ b/botify_docs/templates/homepage.html
@@ -143,11 +143,5 @@
       {% include "partials/footer.html" %}
     </footer>
   </div>
-  <script type="text/javascript">
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
-      analytics.load('5ivE9AeJNB6kq17VSycO582DfUt7F2zw');
-      analytics.page();
-    }}();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
### Description

We noticed that a lot of users in mixpanel are anonymous and don't have any properties and after a small investigation, it seemed that some of them come from developers site. 
At first, I thought that the site was linked directly to mixpanel and that made the issue worse, after further investigation, I found out that this wasn't the case and that it was normal for segment to load the mixpanel script to send events there.

However, my investigation also revealed that the tracked events don't get linked to a user (which is normal since we don't require a login into the site) so we still don't have relevant info about the users sending these events.

I discussed this with Mdan and we agreed that it's better to remove the tracking altogether so it doesn't affect the app analytics.